### PR TITLE
Filter only image mime types.

### DIFF
--- a/admin/class-dominant-colors-lazy-loading-admin.php
+++ b/admin/class-dominant-colors-lazy-loading-admin.php
@@ -143,6 +143,7 @@ class Dominant_Colors_Lazy_Loading_Admin {
 	public function list_images_without_dominant_colors() {
 		$args = array(
 			'post_type'      => 'attachment',
+			'post_mime_type' => 'image',
 			'posts_per_page' => - 1,
 			'meta_key'       => 'dominant_color',
 			'meta_value'     => '',


### PR DESCRIPTION
Filter only 'image' mime types to include only images file types on the files list.

The mime types included are:

> // Image formats
>     'jpg|jpeg|jpe'                 => 'image/jpeg',
>     'gif'                          => 'image/gif',
>     'png'                          => 'image/png',
>     'bmp'                          => 'image/bmp',
>     'tif|tiff'                     => 'image/tiff',
>     'ico'                          => 'image/x-icon',

Reference:
https://codex.wordpress.org/Function_Reference/get_allowed_mime_types

This PR solves the issue https://github.com/Lorti/dominant-colors-lazy-loading-wordpress-plugin/issues/7
