### PR TITLE
Adding 'mousemove' event listener

### DIFF
--- a/public/js/dominant-colors-lazy-loading-public.js
+++ b/public/js/dominant-colors-lazy-loading-public.js
@@ -42,8 +42,14 @@
 		image.classList.remove( 'dcll-placeholder' );
 	};
 
+	var mousemoveFunction = function (event) {
+		check();
+		document.body.removeEventListener('mousemove', mousemoveFunction, false );
+	};
+
 	window.addEventListener( 'load', check, false );
 	window.addEventListener( 'scroll', check, false );
 	window.addEventListener( 'resize', check, false );
 	document.body.addEventListener( 'post-load', check, false );
+	document.body.addEventListener( 'mousemove', mousemoveFunction, false );
 })();

--- a/public/js/dominant-colors-lazy-loading-public.js
+++ b/public/js/dominant-colors-lazy-loading-public.js
@@ -45,6 +45,9 @@
 	var firstUserInteraction = function (event) {
 		check();
 		document.body.removeEventListener('mousemove', firstUserInteraction, false );
+		document.body.removeEventListener( 'keydown', firstUserInteraction, false );
+		document.body.removeEventListener( 'mousedown', firstUserInteraction, false );
+		document.body.removeEventListener( 'touchstart', firstUserInteraction, false );
 	};
 
 	window.addEventListener( 'load', check, false );

--- a/public/js/dominant-colors-lazy-loading-public.js
+++ b/public/js/dominant-colors-lazy-loading-public.js
@@ -42,14 +42,17 @@
 		image.classList.remove( 'dcll-placeholder' );
 	};
 
-	var mousemoveFunction = function (event) {
+	var firstUserInteraction = function (event) {
 		check();
-		document.body.removeEventListener('mousemove', mousemoveFunction, false );
+		document.body.removeEventListener('mousemove', firstUserInteraction, false );
 	};
 
 	window.addEventListener( 'load', check, false );
 	window.addEventListener( 'scroll', check, false );
 	window.addEventListener( 'resize', check, false );
 	document.body.addEventListener( 'post-load', check, false );
-	document.body.addEventListener( 'mousemove', mousemoveFunction, false );
+	document.body.addEventListener( 'mousemove', firstUserInteraction, false );
+	document.body.addEventListener( 'keydown', firstUserInteraction, false );
+	document.body.addEventListener( 'mousedown', firstUserInteraction, false );
+	document.body.addEventListener( 'touchstart', firstUserInteraction, false );
 })();


### PR DESCRIPTION
Adding 'mousemove' event listener to be executed once.
Why? When I use a masony plugin gallery, it can take a while for the page to be fully loaded, and some images in the viewport are not loaded. By adding this event, it fire the 'check' function when the user move the cursor over the body.
I've wrapped the listener in a separeted function to be executed once.