### PR TITLE
Disable for certain images

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To ensure the quality of the plugin please let me know if you encounter any issu
 ### Features
 
 * The plugin calculates the dominant color of an image upon upload.
-* All images attached to posts and pages are automatically replaced with placeholders and load as soon as they enter the viewport to save bandwidth.
+* All images attached to posts and pages are automatically replaced with placeholders and load as soon as they enter the viewport to save bandwidth. To disable placeholders for certain images you can use the class `disable-dcll`.
 * Galleries added via the default `[gallery]` shortcode are also replaced and loaded as soon as they appear in the viewport.
 * A custom filter for lazy-loading thumbnails or featured images can be used in templates and themes (`apply_filters( 'dominant_colors', $image, $id )`).
 * Dominant colors can be calculated for all existing attachments in the plugin settings.

--- a/README.txt
+++ b/README.txt
@@ -19,7 +19,7 @@ To ensure the quality of the plugin please let me know if you encounter any issu
 ### Features
 
 * The plugin calculates the dominant color of an image upon upload.
-* All images attached to posts and pages are automatically replaced with placeholders and load as soon as they enter the viewport to save bandwidth.
+* All images attached to posts and pages are automatically replaced with placeholders and load as soon as they enter the viewport to save bandwidth. To disable placeholders for certain images you can use the class disable-dcll.
 * Galleries added via the default `[gallery]` shortcode are also replaced and loaded as soon as they appear in the viewport.
 * A custom filter for lazy-loading thumbnails or featured images can be used in templates and themes (`apply_filters( 'dominant_colors', $image, $id )`).
 * Dominant colors can be calculated for all existing attachments in the plugin settings.

--- a/public/class-dominant-colors-lazy-loading-public.php
+++ b/public/class-dominant-colors-lazy-loading-public.php
@@ -282,6 +282,10 @@ class Dominant_Colors_Lazy_Loading_Public {
 			return $image;
 		}
 
+		if ( preg_match('/class="[^"]*\bdisable-dcll\b[^"]*"/', $image)) { //if the class disable-dcll is present
+			return $image;
+		}
+
 		$image_src = preg_match( '/src="([^"]+)"/', $image, $match_src ) ? $match_src[1] : '';
 
 		if ( ! $image_src ) {


### PR DESCRIPTION
I added a quick check, to see if the `disable-dcll` class is present in the image, and if so the replacement aborts.
I also referenced this in the readme ;)

Hope this helps